### PR TITLE
Adapting for easy lambda deployment with serverless framework

### DIFF
--- a/sesion-1/.gitignore
+++ b/sesion-1/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/sesion-1/canary.js
+++ b/sesion-1/canary.js
@@ -15,6 +15,7 @@ exports.handler = async event => new Promise((resolve, reject) => {
 		if (error) return reject(error);
 		console.log(`Read canary ${result}`)
 		client.set('canary', 'alive', 'EX', 3 * 60, error => {
+			if (error) return reject(error);
 			console.log('Canary refreshed');
 			client.quit();
 			resolve();

--- a/sesion-1/canary.js
+++ b/sesion-1/canary.js
@@ -12,6 +12,7 @@ exports.handler = async event => new Promise((resolve, reject) => {
 	});
 	
 	client.get('canary', (error, result) => {
+		if (error) return reject(error);
 		console.log(`Read canary ${result}`)
 		client.set('canary', 'alive', 'EX', 3 * 60, error => {
 			console.log('Canary refreshed');

--- a/sesion-1/canary.js
+++ b/sesion-1/canary.js
@@ -1,18 +1,22 @@
 const redis = require('redis');
-const client = redis.createClient({
-	host: 'localhost',
-	port: 6379,
-});
 
-client.on('error', function(error) {
-	console.error(error);
-});
-
-client.get('canary', (error, result) => {
-	console.log(`Read canary ${result}`)
-	client.set('canary', 'alive', 'EX', 3 * 60, error => {
-		console.log('Canary refreshed')
-		client.quit()
+exports.handler = async event => new Promise((resolve, reject) => {
+	const client = redis.createClient({
+		host: process.env.REDIS_HOST || 'localhost',
+		port: 6379,
 	});
-})
-
+	
+	client.on('error', function(error) {
+		console.error(error);
+		reject(error);
+	});
+	
+	client.get('canary', (error, result) => {
+		console.log(`Read canary ${result}`)
+		client.set('canary', 'alive', 'EX', 3 * 60, error => {
+			console.log('Canary refreshed');
+			client.quit();
+			resolve();
+		});
+	})
+});

--- a/sesion-1/package.json
+++ b/sesion-1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sesion-1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "canary.js",
+  "scripts": {
+    "deploy": "sls deploy"
+  },
+  "dependencies": {
+    "redis": "^3.0.2"
+  }
+}

--- a/sesion-1/serverless.yml
+++ b/sesion-1/serverless.yml
@@ -1,0 +1,12 @@
+service: sre
+
+provider:
+  name: aws
+  region: eu-west-3
+
+  environment:
+    REDIS_HOST: ${env:REDIS_HOST}
+
+functions:
+  sre:
+    handler: canary.handler


### PR DESCRIPTION
### In this PR:

- code is adapted for straight lambda execution in AWS
- serverless.yml is configured for easy local deployment with _serverless_ framework

Requirements to run this:
- To install serverless: `npm i serverless -g`
- To have aws credentials ready as profile (in ~/.aws) for quick usage
- To have the redis host available, to be injected as environment variable: `AWS_PROFILE=my_profile REDIS_HOST=my_host sls deploy`